### PR TITLE
Table view decelerating fixed

### DIFF
--- a/AFTabledCollectionView/AFTableViewCell.m
+++ b/AFTabledCollectionView/AFTableViewCell.m
@@ -43,6 +43,7 @@
     self.collectionView.dataSource = dataSourceDelegate;
     self.collectionView.delegate = dataSourceDelegate;
     self.collectionView.indexPath = indexPath;
+    [self.collectionView setContentOffset:self.collectionView.contentOffset animated:NO];
     
     [self.collectionView reloadData];
 }

--- a/AFTabledCollectionView/AFViewController.m
+++ b/AFTabledCollectionView/AFViewController.m
@@ -53,7 +53,7 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-	// Do any additional setup after loading the view, typically from a nib.
+    // Do any additional setup after loading the view, typically from a nib.
 }
 
 - (void)didReceiveMemoryWarning
@@ -65,11 +65,7 @@
 #pragma mark - UITableViewDataSource Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return 2;
-}
-
-- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
-    return [NSString stringWithFormat:@"Section #%d", section+1];
+    return 1;
 }
 
 -(NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
@@ -87,14 +83,14 @@
     {
         cell = [[AFTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
     }
-        
+    
     return cell;
 }
 
 -(void)tableView:(UITableView *)tableView willDisplayCell:(AFTableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [cell setCollectionViewDataSourceDelegate:self indexPath:indexPath];
-    NSInteger index = cell.collectionView.tag;
+    NSInteger index = cell.collectionView.indexPath.row;
     
     CGFloat horizontalOffset = [self.contentOffsetDictionary[[@(index) stringValue]] floatValue];
     [cell.collectionView setContentOffset:CGPointMake(horizontalOffset, 0)];
@@ -116,7 +112,7 @@
 }
 
 -(UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
-{    
+{
     UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:CollectionViewCellIdentifier forIndexPath:indexPath];
     
     NSArray *collectionViewArray = self.colorArray[[(AFIndexedCollectionView *)collectionView indexPath].row];
@@ -133,8 +129,8 @@
     
     CGFloat horizontalOffset = scrollView.contentOffset.x;
     
-    UICollectionView *collectionView = (UICollectionView *)scrollView;
-    NSInteger index = collectionView.tag;
+    AFIndexedCollectionView *collectionView = (AFIndexedCollectionView *)scrollView;
+    NSInteger index = collectionView.indexPath.row;
     self.contentOffsetDictionary[[@(index) stringValue]] = @(horizontalOffset);
 }
 


### PR DESCRIPTION
Fixed the wrong reused cell scrolling. I also changed unused tag property for custom indexPath one in indexedCollectionView. However this approach (storing indexes in dictionary can work with rows, but not with indexes, so I removed the second example section. It can be improved with whole indexPath storing). But it is not the purpose of this commit.

Fixes #15.
